### PR TITLE
Replaced SCRIPT_URL with REDIRECT_URL

### DIFF
--- a/various/wp-rocket-dbugger/inc/functions.php
+++ b/various/wp-rocket-dbugger/inc/functions.php
@@ -203,7 +203,7 @@ function get_hosting_provider()
 
 function dbugger_template_redirect()
 {
-    if ($_SERVER['SCRIPT_URL']=='/downloader/') {
+    if ($_SERVER['REDIRECT_URL']=='/downloader/') {
         $filename = str_replace('url=', '', $_SERVER['QUERY_STRING']);
         $site_url = site_url();
         $site_url = preg_replace('#^https?://#i', '', $site_url);


### PR DESCRIPTION
`$_SERVER` doesn't have any `SCRIPT_URL` element.  `REDIRECT_URL` seems to hold the information that you are after `/downloader/`