### PR TITLE
adding new default OCI elements - section and header

### DIFF
--- a/critical-images/wp-rocket-critical-images-parameters/wp-rocket-critical-images-parameters.php
+++ b/critical-images/wp-rocket-critical-images-parameters/wp-rocket-critical-images-parameters.php
@@ -45,6 +45,8 @@ function set_critical_images_parameters() {
       'div',
       'li',
       'svg',
+      'section',
+      'header',
     ),
       // The delay before the LCP beacon is triggered.
       'rocket_lcp_delay' => 500,
@@ -154,8 +156,7 @@ add_filter( 'rocket_atf_elements', __NAMESPACE__ . '\change_rocket_atf_elements'
 /**
  * Change the delay before the LCP beacon is triggered.
  */
-function change_rocket_lcp_delay()
-{
+function change_rocket_lcp_delay() {
 
     $critical_images_parameters = set_critical_images_parameters();
 


### PR DESCRIPTION
# Description

In version 3.16.1, we introduced new default elements considered for OCI (section and header):
https://github.com/wp-media/wp-rocket/issues/6667
https://github.com/wp-media/wp-rocket/issues/6631

This update makes those elements included by default as well in the Critical Images Parameters helper.


- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
