### PR TITLE
adding notes to readme files with instructions about which helper to use

### DIFF
--- a/_deprecated/wp-rocket-critical-images-parameters/README.md
+++ b/_deprecated/wp-rocket-critical-images-parameters/README.md
@@ -2,6 +2,8 @@
 
 Change the critical images optimization cleanup interval, warmup links number, width and height thresholds for both desktop and mobile, elements considered for the optimization, and the delay before the LCP beacon script is triggered.
 
+⚠ Only use this helper with WP Rocket versions 3.16 through 3.16.3. If you're using WP Rocket version 3.16.4 or later, please use the [WP Rocket | Performance Hints Parameters](https://github.com/wp-media/wp-rocket-helpers/tree/master/performance-hints/wp-rocket-perf-hints-parameters) plugin instead.
+
 📝&#160;&#160;**Manual code edit required before use!**
 
 Change: 

--- a/performance-hints/wp-rocket-perf-hints-parameters/README.md
+++ b/performance-hints/wp-rocket-perf-hints-parameters/README.md
@@ -1,6 +1,10 @@
 # WP Rocket | Performance Hints Parameters
 <br>
 
+⚠ Only use this helper with WP Rocket versions 3.16.4 and later. If you're using WP Rocket version 3.16 through 3.16.3, please use the [WP Rocket | Critical Images Parameters](https://github.com/wp-media/wp-rocket-helpers/tree/master/_deprecated/wp-rocket-critical-images-parameters) plugin instead. If you're using a WP Rocket version prior to 3.16, neither of these helper plugins should be used.
+
+<br>
+
 ### Changes the following Performance Hints Optimization parameters:
 - Warmup links number
 - Width and height thresholds for both desktop and mobile


### PR DESCRIPTION
# Description

Updating the README.md files of these helpers:

[WP Rocket | Performance Hints Parameters](https://github.com/wp-media/wp-rocket-helpers/tree/master/performance-hints/wp-rocket-perf-hints-parameters)

[WP Rocket | Critical Images Parameters](https://github.com/wp-media/wp-rocket-helpers/tree/master/_deprecated/wp-rocket-critical-images-parameters)

To instruct which one should be used depending on which WP Rocket version they are using.