### PR TITLE
Fix/wp rocket mobile detect classname

### DIFF
--- a/lazyload/wp-rocket-no-lazyload-mobile-cache/wp-rocket-no-lazyload-mobile-cache.php
+++ b/lazyload/wp-rocket-no-lazyload-mobile-cache/wp-rocket-no-lazyload-mobile-cache.php
@@ -23,9 +23,9 @@ defined( 'ABSPATH' ) or die();
  */
 function deactivate_for_mobile_devices() {
 
-	if( class_exists( 'Rocket_Mobile_Detect' ) && get_rocket_option( 'do_caching_mobile_files', false ) ) {
+	if( class_exists( 'WP_Rocket_Mobile_Detect' ) && get_rocket_option( 'do_caching_mobile_files', false ) ) {
 
-		$detect = new \Rocket_Mobile_Detect();
+		$detect = new \WP_Rocket_Mobile_Detect();
 
 		if ( $detect->isMobile() && ! $detect->isTablet() ) {
 

--- a/various/wp-rocket-no-features-for-mobile-page/wp-rocket-no-features-for-mobile-page.php
+++ b/various/wp-rocket-no-features-for-mobile-page/wp-rocket-no-features-for-mobile-page.php
@@ -24,9 +24,9 @@ defined( 'ABSPATH' ) or die();
  */
 function deactivate_for_mobile_devices() {
 	
-	if( class_exists( 'Rocket_Mobile_Detect' ) && get_rocket_option( 'do_caching_mobile_files', false ) ) {
+	if( class_exists( 'WP_Rocket_Mobile_Detect' ) && get_rocket_option( 'do_caching_mobile_files', false ) ) {
 		
-		$detect = new \Rocket_Mobile_Detect();
+		$detect = new \WP_Rocket_Mobile_Detect();
 		
 		// You can change is_page condition or add new to target whatever you want
 		if ( $detect->isMobile() && ! $detect->isTablet() && is_page( array( 2374 ) ) ) {


### PR DESCRIPTION
# Description

The `class_exists('Rocket_Mobile_Detect')` doesn't return the expect value.

Correct the class name usage from `Rocket_Mobile_Detect` to `WP_Rocket_Mobile_Detect`

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release

## Detailed scenario

Install the helper plugins using the `class_exists()` verification.

## Technical description

# Mandatory Checklist

## Code validation

- [ ] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [ ] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [ ] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

*If some mandatory items are not relevant, explain why in this section.*

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
